### PR TITLE
Pass allow_multiple_responses setting when creating a Petition

### DIFF
--- a/actionkit/petitions.py
+++ b/actionkit/petitions.py
@@ -20,7 +20,7 @@ class Petitions(HttpMethods):
         return (page_uri, cms_form_uri, followup_uri)
 
     def create_from_model(self, model, page, content, followup):
-        base_page = {k: model[k] for k in ["language", "goal", "goal_type", "recognize"]}
+        base_page = {k: model[k] for k in ["language", "goal", "goal_type", "recognize", "allow_multiple_responses"]}
         new_page = base_page | page
         new_page["fields"] = model["fields"] | page["fields"]
         new_page["groups"] = new_page.get("groups", []) + [g["resource_uri"] for g in model["groups"]]


### PR DESCRIPTION
The Petition.create_from_model would ignore the allow_multiple_responses value when creating a petition, and a default value would be used by backend (which seems to be True). This change fixes the problem where youmove-form would create petitions with this setting set to yes.